### PR TITLE
Ensure tests run via Yarn classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ $ yarn native:run-android
 - Webpack doesn't generate correct source maps on web
 - You will encounter some problems if you try to run the app on iOS or Android, the code is not (yet) optimised to run on there
 
+## Running tests
+
+Install dependencies with `yarn install` and run the unit tests using:
+
+```bash
+yarn test
+```
+
 ## License
 
 MIT License

--- a/package.json
+++ b/package.json
@@ -78,5 +78,6 @@
     "webpack-hot-middleware": "^2.21.0",
     "webpack-jarvis": "^0.1.1",
     "workbox-webpack-plugin": "^3.0.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Summary
- document how to run tests
- specify Yarn 1.x in `package.json` so `yarn` installs work

## Testing
- `yarn install`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684b042907c083229783c71c67ebee97